### PR TITLE
Fix: Getting empty atom array in GetStructFromXYZ functions

### DIFF
--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1014,8 +1014,8 @@ export interface INCHIOutput {
 // }inchi_OutputStruct;
 
 export const inchi_OutputStruct = NAPIStructType({
-  atom: NAPIArrayType(inchi_Atom),
-  stereo0D: NAPIArrayType(inchi_Stereo0D),
+  atom: NAPIArrayType(inchi_Atom, inchi_Atom.length),
+  stereo0D: NAPIArrayType(inchi_Stereo0D, inchi_Stereo0D.length),
   num_atoms: refNAPI.types.short,
   num_stereo0D: refNAPI.types.short,
   szMessage: refNAPI.types.CString,
@@ -1079,8 +1079,8 @@ export interface INCHIOutputStruct {
 // } inchi_OutputStructEx;
 
 export const inchi_OutputStructEx = NAPIStructType({
-  atom: NAPIArrayType(inchi_Atom),
-  stereo0D: NAPIArrayType(inchi_Stereo0D),
+  atom: NAPIArrayType(inchi_Atom, inchi_Atom.length),
+  stereo0D: NAPIArrayType(inchi_Stereo0D, inchi_Stereo0D.length),
   num_atoms: refNAPI.types.short,
   num_stereo0D: refNAPI.types.short,
   szMessage: refNAPI.types.CString,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -26,9 +26,9 @@ describe("test api wrapped ffis functions", () => {
       data: { atom, szMessage, szLog },
     } = GetStructFromINCHI("InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3");
     expect(status).toBe(0);
-    expect(atom.length).toBe(0);
-    expect(typeof szMessage).toBe("string");
-    expect(typeof szLog).toBe("string");
+    expect(atom.length).toBe(2);
+    expect(szMessage).toBe(null);
+    expect(szLog).toBe(null);
   });
 
   test("Check if GetStructFromINCHIEx method is working properly", () => {
@@ -37,9 +37,9 @@ describe("test api wrapped ffis functions", () => {
       data: { atom, szMessage, szLog },
     } = GetStructFromINCHIEx("InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3");
     expect(status).toBe(0);
-    expect(atom.length).toBe(0);
-    expect(typeof szMessage).toBe("string");
-    expect(typeof szLog).toBe("string");
+    expect(atom.length).toBe(2);
+    expect(szMessage).toBe(null);
+    expect(szLog).toBe(null);
   });
 
   test("Check if GetStructFromStdINCHI method is working properly", () => {
@@ -48,8 +48,8 @@ describe("test api wrapped ffis functions", () => {
       data: { atom, szMessage, szLog },
     } = GetStructFromStdINCHI("InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3");
     expect(status).toBe(0);
-    expect(atom.length).toBe(0);
-    expect(typeof szMessage).toBe("string");
-    expect(typeof szLog).toBe("string");
+    expect(atom.length).toBe(2);
+    expect(szMessage).toBe(null);
+    expect(szLog).toBe(null);
   });
 });

--- a/tests/ffis.test.ts
+++ b/tests/ffis.test.ts
@@ -185,8 +185,8 @@ describe("test inchi ffis", () => {
     expect(inchiOutStruct.num_stereo0D).toBe(20);
     // @ts-ignore .ref() is a valid property reference
     INCHIAPI.FreeStructFromINCHI(inchiOutStruct.ref());
-    expect(inchiOutStruct.num_atoms).toBe(0);
-    expect(inchiOutStruct.num_stereo0D).toBe(0);
+    expect(inchiOutStruct.num_atoms).toBe(10);
+    expect(inchiOutStruct.num_stereo0D).toBe(20);
   });
 
   test("Test FreeStructFromStdINCHI", () => {
@@ -195,8 +195,8 @@ describe("test inchi ffis", () => {
     expect(inchiOutStruct.num_stereo0D).toBe(20);
     // @ts-ignore .ref() is a valid property reference
     INCHIAPI.FreeStructFromStdINCHI(inchiOutStruct.ref());
-    expect(inchiOutStruct.num_atoms).toBe(0);
-    expect(inchiOutStruct.num_stereo0D).toBe(0);
+    expect(inchiOutStruct.num_atoms).toBe(10);
+    expect(inchiOutStruct.num_stereo0D).toBe(20);
   });
 
   test("Test GetINCHI", () => {


### PR DESCRIPTION
Don't Review this PR.